### PR TITLE
Removed java.util.Objects

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -29,7 +29,6 @@ import java.lang.Thread;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 
 public class AudioPlayerModule extends ReactContextBaseJavaModule implements MediaPlayer.OnInfoListener,
         MediaPlayer.OnErrorListener, MediaPlayer.OnCompletionListener, MediaPlayer.OnSeekCompleteListener,
@@ -404,7 +403,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
     // Find playerId matching player from playerPool
     private Integer getPlayerId(MediaPlayer player) {
         for (Entry<Integer, MediaPlayer> entry : playerPool.entrySet()) {
-            if (Objects.equals(player, entry.getValue())) {
+            if (equals(player, entry.getValue())) {
                 return entry.getKey();
             }
         }
@@ -496,5 +495,10 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         emitEvent(playerId, "info", data);
 
         return false;
+    }
+
+    // Utils
+    public static boolean equals(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
     }
 }


### PR DESCRIPTION
Replaced the `java.util.Objects` usage since it has been added on API level 19 (this library should works with API >= 16).
I just tested it on 3 emulators and it seems to work correctly :)