### PR TITLE
Add properties in Info.plist for iOS in ExampleApp

### DIFF
--- a/ExampleApp/ios/ExampleApp/Info.plist
+++ b/ExampleApp/ios/ExampleApp/Info.plist
@@ -24,6 +24,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>To record sound for testing</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
- *NSMicrophoneUsageDescription* is necessary for testing on actual device. This is not required for running on iOS simulator.
- *UIBackgroundModes* is the only required fields for background play in iOS according to our investigation. I think this field is better to set to be true for ExampleApp because lots of RN developer might be curious if this library can play audio in background.