### PR TITLE
Update on documentation regarding iOS background playback

### DIFF
--- a/ExampleApp/README.md
+++ b/ExampleApp/README.md
@@ -8,9 +8,6 @@ Expecting you have the React Native development environment in place:
 
 #### Android
 
-![Screenshot](https://cloud.githubusercontent.com/assets/1323963/23828897/d45deda4-0723-11e7-9521-66e556d05c5a.png)
-
-
 ```sh
 cd ExampleApp
 npm install         # make sure you do this inside ExampleApp/
@@ -22,8 +19,6 @@ react-native run-android
 ```
 
 #### iOS
-
-![Screenshot](https://cloud.githubusercontent.com/assets/1323963/23828898/d465810e-0723-11e7-8a65-8b56f2863d96.png)
 
 ```sh
 cd ExampleApp

--- a/ExampleApp/README.md
+++ b/ExampleApp/README.md
@@ -1,0 +1,37 @@
+react-native-audio-toolkit demo
+===============================
+
+Running the demo app
+--------------------
+
+Expecting you have the React Native development environment in place:
+
+#### Android
+
+![Screenshot](https://cloud.githubusercontent.com/assets/1323963/23828897/d45deda4-0723-11e7-9521-66e556d05c5a.png)
+
+
+```sh
+cd ExampleApp
+npm install         # make sure you do this inside ExampleApp/
+npm start
+
+# In a separate terminal, run:
+adb reverse tcp:8081 tcp:8081
+react-native run-android
+```
+
+#### iOS
+
+![Screenshot](https://cloud.githubusercontent.com/assets/1323963/23828898/d465810e-0723-11e7-8a65-8b56f2863d96.png)
+
+```sh
+cd ExampleApp
+npm install         # make sure you do this inside ExampleApp/
+
+# Then:
+# 1. Open ExampleApp/ios/ExampleApp.xcodeproj in Xcode
+# 2. Click on the run button
+```
+
+Then start clicking the buttons, it should be quite simple. By default, the background playback for iOS is enabled.

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,10 @@ Media methods
 
     Initialize the player for playback of song in `path`. Path can be either
     filename, network URL or a file URL to resource. The library tries to parse
-    the provided path to the best of it's abilities.
+    the provided path to the best of it's abilities. For local files, the path should have 'file://' as its prefix. Please refer the examples below.
+    
+    - iOS: file:///Users/.../test.mp4
+    - Android: file:///data/data/.../test.m4a
 
     See [SOURCES.md](/docs/SOURCES.md) for more information.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,13 +20,16 @@ Media methods
       // Boolean to indicate whether the player should self-destruct after
       // playback is finished. If this is not set, you are responsible for
       // destroying the object by calling player.destroy().
-      autoDestroy : boolean (default: True),
+      autoDestroy : boolean (default: true),
 
-      // (Android only) Should playback continue if app is sent to background?
-      // iOS will always pause in this case.
-      continuesToPlayInBackground : boolean (default: False)
+      // (Android only) Should playback continue if app is sent to background
+      // For iOS background playback, please refer the screenshot below
+      continuesToPlayInBackground : boolean (default: false)
     }
     ```
+  
+    ![Screenshot](https://cloud.githubusercontent.com/assets/1323963/23828922/69c128ca-0724-11e7-9d56-167407040625.png)
+    To supprt background play in iOS, please enable the 'Audio, AirPlay, and Picture' option in 'Project - Capabilities - Background Modes'.
 
 
 * `prepare(Function callback)`


### PR DESCRIPTION
- It closes #22.
- I added explanation on how to enable iOS background playback support.
- I added screenshots for both platform (it can be deleted depending on the collaborator's choice).

I found there is merge conflict, but I believe that is not a critical issue, please update it as you wish :)