### PR TITLE
Changed prepare to prepareAsync on Android

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -517,6 +517,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
     {
         switch (focusChange)
         {
+            case AudioManager.AUDIOFOCUS_LOSS:
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 MediaPlayer player = this.playerPool.get(this.lastPlayerId);
                 if(player != null) player.pause();

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -519,17 +519,11 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         {
             case AudioManager.AUDIOFOCUS_LOSS:
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                MediaPlayer player = this.playerPool.get(this.lastPlayerId);
-                if(player != null) {
+                //MediaPlayer player = this.playerPool.get(this.lastPlayerId);
+                WritableMap data = new WritableNativeMap();
+                data.putString("message", "Lost audio focus, playback paused");
 
-                    player.pause();
-
-                    WritableMap info = this.getInfo(player);
-                    WritableMap data = new WritableNativeMap();
-                    data.putString("message", "Lost audio focus, playback paused");
-
-                    this.emitEvent(this.lastPlayerId, "forcePause", data);
-                }
+                this.emitEvent(this.lastPlayerId, "forcePause", data);
                 break;
         }
     }

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -527,9 +527,8 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
                     WritableMap info = this.getInfo(player);
                     WritableMap data = new WritableNativeMap();
                     data.putString("message", "Lost audio focus, playback paused");
-                    data.putMap("info", info);
 
-                    this.emitEvent(this.lastPlayerId, "pause", data);
+                    this.emitEvent(this.lastPlayerId, "forcePause", data);
                 }
                 break;
         }

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -32,7 +32,7 @@ import java.util.Map.Entry;
 
 public class AudioPlayerModule extends ReactContextBaseJavaModule implements MediaPlayer.OnInfoListener,
         MediaPlayer.OnErrorListener, MediaPlayer.OnCompletionListener, MediaPlayer.OnSeekCompleteListener,
-        MediaPlayer.OnBufferingUpdateListener, LifecycleEventListener, MediaPlayer.OnPreparedListener {
+        MediaPlayer.OnBufferingUpdateListener, LifecycleEventListener {
     private static final String LOG_TAG = "AudioPlayerModule";
 
     Map<Integer, MediaPlayer> playerPool = new HashMap<>();
@@ -255,7 +255,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         player.setOnInfoListener(this);
         player.setOnCompletionListener(this);
         player.setOnSeekCompleteListener(this);
-        player.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
+        player.setOnPreparedListener(new MediaPlayer.OnPreparedListener() { // Async preparing, so we need to run the callback after preparing has finished
 
             @Override
             public void onPrepared(MediaPlayer player) {
@@ -418,12 +418,6 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         return null;
     }
 
-
-
-    @Override
-    public void onPrepared(MediaPlayer player) {
-
-    }
 
     @Override
     public void onBufferingUpdate(MediaPlayer player, int percent) {

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -373,8 +373,19 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         }
 
         try {
+
             player.pause();
+
+            WritableMap info = getInfo(player);
+
+            WritableMap data = new WritableNativeMap();
+            data.putString("message", "Playback paused");
+            data.putMap("info", info);
+
+            emitEvent(playerId, "pause", data);
+
             callback.invoke(null, getInfo(player));
+
         } catch (Exception e) {
             callback.invoke(errObj("pause", e.toString()));
         }

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -523,8 +523,12 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
                 if(player != null) {
 
                     player.pause();
+
+                    WritableMap info = this.getInfo(player);
                     WritableMap data = new WritableNativeMap();
-                    data.putString("message", "Lost Audio Focus");
+                    data.putString("message", "Lost audio focus, playback paused");
+                    data.putMap("info", info);
+
                     this.emitEvent(this.lastPlayerId, "pause", data);
                 }
                 break;

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -520,7 +520,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
             case AudioManager.AUDIOFOCUS_LOSS:
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 MediaPlayer player = this.playerPool.get(this.lastPlayerId);
-                if(player != null) this.pause(this.lastPlayerId,null);
+                if(player != null) player.pause();
                 break;
         }
     }

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -32,7 +32,7 @@ import java.util.Map.Entry;
 
 public class AudioPlayerModule extends ReactContextBaseJavaModule implements MediaPlayer.OnInfoListener,
         MediaPlayer.OnErrorListener, MediaPlayer.OnCompletionListener, MediaPlayer.OnSeekCompleteListener,
-        MediaPlayer.OnBufferingUpdateListener, LifecycleEventListener {
+        MediaPlayer.OnBufferingUpdateListener, LifecycleEventListener, MediaPlayer.OnPreparedListener {
     private static final String LOG_TAG = "AudioPlayerModule";
 
     Map<Integer, MediaPlayer> playerPool = new HashMap<>();
@@ -220,7 +220,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
     }
 
     @ReactMethod
-    public void prepare(Integer playerId, String path, ReadableMap options, Callback callback) {
+    public void prepare(Integer playerId, String path, ReadableMap options, final Callback callback) {
         if (path == null || path.isEmpty()) {
             callback.invoke(errObj("nopath", "Provided path was empty"));
             return;
@@ -255,6 +255,14 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         player.setOnInfoListener(this);
         player.setOnCompletionListener(this);
         player.setOnSeekCompleteListener(this);
+        player.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
+
+            @Override
+            public void onPrepared(MediaPlayer player) {
+                callback.invoke(null, getInfo(player));
+            }
+
+        });
 
         this.playerPool.put(playerId, player);
 
@@ -276,9 +284,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         this.playerContinueInBackground.put(playerId, continueInBackground);
 
         try {
-            player.prepare();
-
-            callback.invoke(null, getInfo(player));
+            player.prepareAsync();
         } catch (Exception e) {
             callback.invoke(errObj("prepare", e.toString()));
         }
@@ -332,6 +338,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
 
         callback.invoke();
     }
+
 
     @ReactMethod
     public void play(Integer playerId, Callback callback) {
@@ -409,6 +416,13 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         }
 
         return null;
+    }
+
+
+
+    @Override
+    public void onPrepared(MediaPlayer player) {
+
     }
 
     @Override

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -520,7 +520,7 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
             case AudioManager.AUDIOFOCUS_LOSS:
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 MediaPlayer player = this.playerPool.get(this.lastPlayerId);
-                if(player != null) player.pause();
+                if(player != null) this.pause(this.lastPlayerId,null);
                 break;
         }
     }

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -520,7 +520,13 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
             case AudioManager.AUDIOFOCUS_LOSS:
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 MediaPlayer player = this.playerPool.get(this.lastPlayerId);
-                if(player != null) player.pause();
+                if(player != null) {
+
+                    player.pause();
+                    WritableMap data = new WritableNativeMap();
+                    data.putString("message", "Lost Audio Focus");
+                    this.emitEvent(this.lastPlayerId, "pause", data);
+                }
                 break;
         }
     }

--- a/src/Player.js
+++ b/src/Player.js
@@ -161,8 +161,7 @@ class Player extends EventEmitter {
 
   pause(callback = _.noop) {
     RCTAudioPlayer.pause(this._playerId, (err, results) => {
-      //this._updateState(err, MediaStates.PAUSED, [results]);
-      this._handleEvent("pause",null);
+      //this._updateState(err, MediaStates.PAUSED, [results]); // We are sending a pause event on the native side
       callback(err);
     });
 

--- a/src/Player.js
+++ b/src/Player.js
@@ -161,7 +161,8 @@ class Player extends EventEmitter {
 
   pause(callback = _.noop) {
     RCTAudioPlayer.pause(this._playerId, (err, results) => {
-      this._updateState(err, MediaStates.PAUSED, [results]);
+      //this._updateState(err, MediaStates.PAUSED, [results]);
+      this._handleEvent("pause",null);
       callback(err);
     });
 


### PR DESCRIPTION
This PR changes the prepare method of MediaPlayer to prepareAsync. If we use prepare, the UI gets blocked while preparing the file, this causes a bad user experience if you load files via HTTP. Using prepareAsync solves this issue.