### PR TITLE
fix a bug when finding audio file on Android.

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -125,19 +125,6 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         String fileNameWithoutExt;
         String extPath;
 
-        // Try finding file in Android "raw" resources
-        if (path.lastIndexOf('.') != -1) {
-            fileNameWithoutExt = path.substring(0, path.lastIndexOf('.'));
-        } else {
-            fileNameWithoutExt = path;
-        }
-
-        int resId = this.context.getResources().getIdentifier(fileNameWithoutExt,
-            "raw", this.context.getPackageName());
-        if (resId != 0) {
-            return Uri.parse("android.resource://" + this.context.getPackageName() + "/" + resId);
-        }
-
         // Try finding file in app data directory
         extPath = new ContextWrapper(this.context).getFilesDir() + "/" + path;
         file = new File(extPath);
@@ -156,6 +143,19 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         file = new File(path);
         if (file.exists()) {
             return Uri.fromFile(file);
+        }
+        
+        // Try finding file in Android "raw" resources
+        if (path.lastIndexOf('.') != -1) {
+            fileNameWithoutExt = path.substring(0, path.lastIndexOf('.'));
+        } else {
+            fileNameWithoutExt = path;
+        }
+
+        int resId = this.context.getResources().getIdentifier(fileNameWithoutExt,
+            "raw", this.context.getPackageName());
+        if (resId != 0) {
+            return Uri.parse("android.resource://" + this.context.getPackageName() + "/" + resId);
         }
 
         // Otherwise pass whole path string as URI and hope for the best


### PR DESCRIPTION
Hi, when we play the given video file , there is bug if we put the code of finding the android raw resources at first, for example, if we have finished to recording a 233.mp3 and try to play it. we are supposed to do:
`
new Player(233.mp3).play();
`
but in your former logic , it will search the file in android raw resources first, and the name 233 can be convert to a int resID which is not equal to 0, so your code will return the wrong path which can not be find.

I have cost me almost a whole day to find why I can not play the recorded audio and fixed it.  