### PR TITLE
Remove override of createJSModules to support react-native 0.47.0 and above

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPackage.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPackage.java
@@ -19,7 +19,7 @@ public class AudioPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // @Override 
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Your work is awesome, it seems to be you do not keep it updated with react-native.

From react-native 0.47 they were removed unused createJSModules calls.


Thanks.