### PR TITLE
Fix false currentTime returns

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/android/lib/src/main/AndroidManifest.xml
+++ b/android/lib/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPlayerModule.java
@@ -425,6 +425,31 @@ public class AudioPlayerModule extends ReactContextBaseJavaModule implements Med
         }
     }
 
+    @ReactMethod
+    public void updateCurrentTime(Integer playerId, Callback callback) {
+        MediaPlayer player = this.playerPool.get(playerId);
+        if (player == null) {
+            callback.invoke(errObj("notfound", "playerId " + playerId + " not found."));
+            return;
+        }
+
+        try {
+
+            WritableMap info = getInfo(player);
+
+            WritableMap data = new WritableNativeMap();
+            data.putString("message", "Update current time");
+            data.putMap("info", info);
+
+            emitEvent(playerId, "updateCurrentTime", data);
+
+            callback.invoke(null, getInfo(player));
+
+        } catch (Exception e) {
+            callback.invoke(errObj("updateCurrentTime", e.toString()));
+        }
+    }
+
     // Find playerId matching player from playerPool
     private Integer getPlayerId(MediaPlayer player) {
         for (Entry<Integer, MediaPlayer> entry : playerPool.entrySet()) {

--- a/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
+++ b/ios/ReactNativeAudioToolkit/ReactNativeAudioToolkit/AudioPlayer.m
@@ -327,6 +327,20 @@ RCT_EXPORT_METHOD(resume:(nonnull NSNumber*)playerId withCallback:(RCTResponseSe
     callback(@[[NSNull null]]);
 }
 
+RCT_EXPORT_METHOD(updateCurrentTime:(nonnull NSNumber*)playerId withCallback:(RCTResponseSenderBlock)callback) {
+    AVPlayer* player = [self playerForKey:playerId];
+    
+    if (!player) {
+        NSDictionary* dict = [Helpers errObjWithCode:@"notfound"
+                                         withMessage:[NSString stringWithFormat:@"playerId %@ not found.", playerId]];
+        callback(@[dict]);
+        return;
+    }
+
+    callback(@[[NSNull null], @{@"duration": @(CMTimeGetSeconds(player.currentItem.asset.duration) * 1000),
+                                @"position": @(CMTimeGetSeconds(player.currentTime) * 1000)}]);
+}
+
 
 -(void)itemDidFinishPlaying:(NSNotification *) notification {
     NSNumber *playerId = ((ReactPlayerItem *)notification.object).reactPlayerId;

--- a/src/Player.js
+++ b/src/Player.js
@@ -243,7 +243,6 @@ class Player extends EventEmitter {
   get currentTime() {
     RCTAudioPlayer.updateCurrentTime(this._playerId, (err, results) => {
       this._updateState(err, this._state, [results]);
-      callback(err);
     });
 
     return this._position;

--- a/src/Player.js
+++ b/src/Player.js
@@ -242,7 +242,8 @@ class Player extends EventEmitter {
 
   get currentTime() {
     RCTAudioPlayer.updateCurrentTime(this._playerId, (err, results) => {
-      this._updateState(err, this._state, [results]);
+      const info = _.last(_.filter(results, _.identity));
+      this._storeInfo(info);
     });
 
     return this._position;

--- a/src/Player.js
+++ b/src/Player.js
@@ -241,18 +241,11 @@ class Player extends EventEmitter {
   }
 
   get currentTime() {
-    let pos = -1;
+    RCTAudioPlayer.updateCurrentTime(this._playerId, (err, results) => {
+      this._updateState(err, this._state, [results]);
+      callback(err);
+    });
 
-    if (this._position < 0) {
-      return -1;
-    }
-
-    if (this._state === MediaStates.PLAYING) {
-      pos = this._position + (Date.now() - this._lastSync);
-      pos = Math.min(pos, this._duration);
-
-      return pos;
-    }
     return this._position;
   }
 

--- a/src/Player.js
+++ b/src/Player.js
@@ -242,8 +242,7 @@ class Player extends EventEmitter {
 
   get currentTime() {
     RCTAudioPlayer.updateCurrentTime(this._playerId, (err, results) => {
-      const info = _.last(_.filter(results, _.identity));
-      this._storeInfo(info);
+      this._storeInfo(results);
     });
 
     return this._position;


### PR DESCRIPTION
The currentTime property does not reflect the current time in the recording. With this change, the currentTime property will always return the correct value.