### PR TITLE
destory the recorder in stop method

### DIFF
--- a/src/Recorder.js
+++ b/src/Recorder.js
@@ -114,6 +114,7 @@ class Recorder extends EventEmitter {
       });
     } else {
       setTimeout(callback, 0);
+      this.destroy();
     }
 
     return this;


### PR DESCRIPTION
Hi, I have noticed that if we call stop() after record() immediately(the recorder may not have start recording)and it will lead to a problem(illegalStateException) in Android Platform(haven't found this issue in iOS) when we call recorder.start() in native code.I guess it is a result of not releasing the created recorder, so I call destroy() in stop() if the MediaState is not RECORDING to avoid this.