### PR TITLE
Android/iOS on Progress Listener fix Removed unneeded Override Annotation on Android

### DIFF
--- a/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPackage.java
+++ b/android/lib/src/main/java/com/futurice/rctaudiotoolkit/AudioPackage.java
@@ -19,7 +19,6 @@ public class AudioPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Override Annotation in `AudioPackage.java` breaks project, it is unneeded and deprecated since RN 0.47